### PR TITLE
Migrate to Air code formatting

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^\.httr-oauth$
 ^\.secrets$
 ^\.lintr$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,12 +34,54 @@ Our procedures for contributing bigger changes, code in particular, generally fo
 ### Code style
 
 - New code should follow the tidyverse [style guide](https://style.tidyverse.org).
-  You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.
+  We use [Air](https://posit-dev.github.io/air/) for code formatting.
 
 - We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.
 
 - We use [testthat](https://cran.r-project.org/package=testthat) for unit tests.
   Contributions with test cases included are easier to accept.
+
+#### Setting up Air
+
+The project contains configuration files (`air.toml`, `.vscode/`) that ensure formatting is scoped to this repository only—your personal projects remain unaffected.
+
+**Positron**
+
+Air ships built-in with Positron. The project settings are already configured, so format-on-save is enabled automatically when working in this repo.
+
+**VS Code**
+
+1. Install the [Air extension](https://marketplace.visualstudio.com/items?itemName=Posit.air-vscode)
+2. The project settings are already configured, so format-on-save is enabled automatically when working in this repo
+
+**RStudio (2024.12.0+)**
+
+RStudio requires manual setup. Note that RStudio does not support per-project settings, so these are global options.
+
+1. Install the Air CLI:
+   - macOS/Linux: `curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh`
+   - macOS (Homebrew): `brew install air`
+   - Windows: `powershell -ExecutionPolicy Bypass -c "irm https://github.com/posit-dev/air/releases/latest/download/air-installer.ps1 | iex"`
+
+2. In RStudio, go to **Tools > Global Options > Code > Formatting** and:
+   - Check "Use external formatter"
+   - Set "Reformat command:" to `{path/to/air} format` (find the path with `which air` on macOS/Linux)
+   - See the [RStudio setup guide](https://posit-dev.github.io/air/editor-rstudio.html) for more details
+
+3. Optionally, enable format-on-save globally:
+   - In the same settings pane, check "Format code on save"
+   - **Note:** This applies to all projects, not just hubverse repos
+
+4. If you prefer not to enable format-on-save globally, format manually before committing:
+   - Use **Code > Reformat Code** (Cmd/Ctrl+Shift+A) or right-click and select "Reformat Code"
+   - CI will check formatting on PRs and fail if code is not formatted
+
+**Command Line**
+
+Works from any terminal:
+- Format entire project: `air format .`
+- Check without modifying: `air format . --check`
+
 
 ## Code of Conduct
 

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: format-check.yaml
+
+permissions: read-all
+
+jobs:
+  format-check:
+    name: format-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Air
+        uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1
+
+      - name: Check formatting
+        run: air format . --check
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "[r]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "Posit.air-vscode"
+    },
+    "[quarto]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "quarto.quarto"
+    }
+}

--- a/R/use_hub_github_action.R
+++ b/R/use_hub_github_action.R
@@ -42,10 +42,12 @@ use_hub_github_action <- function(name, ref = NULL) {
 # usethis internal utilities:
 # https://github.com/r-lib/usethis/blob/9ac020dbf6b7d42e4f7915fec567184acd671826/R/github-actions.R#L259-L283
 latest_release <- function() {
-  raw_releases <- gh::gh("/repos/{owner}/{repo}/releases",
+  raw_releases <- gh::gh(
+    "/repos/{owner}/{repo}/releases",
     owner = "hubverse-org",
     repo = "hubverse-actions",
-    .api_url = "https://github.com", .limit = Inf
+    .api_url = "https://github.com",
+    .limit = Inf
   )
 
   tag_names <- purrr::discard(

--- a/tests/testthat/test-use_hub_github_action.R
+++ b/tests/testthat/test-use_hub_github_action.R
@@ -3,25 +3,28 @@ test_that("use_hub_github_action works", {
   orig_wd <- getwd()
   on.exit(setwd(orig_wd))
 
-  usethis::create_project(proj_path,
-    rstudio = FALSE,
-    open = FALSE
-  )
+  usethis::create_project(proj_path, rstudio = FALSE, open = FALSE)
   setwd(proj_path)
   use_hub_github_action(name = "validate-submission")
 
   ga_path <- ".github/workflows/validate-submission.yaml"
-  expect_true(".github" %in% fs::path_file(
-    fs::dir_ls(proj_path, all = TRUE)
-  ))
+  expect_true(
+    ".github" %in%
+      fs::path_file(
+        fs::dir_ls(proj_path, all = TRUE)
+      )
+  )
   expect_true(fs::file_exists(ga_path))
   expect_gt(length(readLines(ga_path)), 0)
   expect_false(any(grepl("remotes::install_github", readLines(ga_path))))
 
   fs::file_delete(ga_path)
-  expect_false(ga_path %in% fs::path_file(
-    fs::dir_ls(proj_path, all = TRUE)
-  ))
+  expect_false(
+    ga_path %in%
+      fs::path_file(
+        fs::dir_ls(proj_path, all = TRUE)
+      )
+  )
 
   use_hub_github_action(name = "validate-submission", ref = "v0.0.1")
 


### PR DESCRIPTION
## Summary

- Set up [Air](https://posit-dev.github.io/air/) code formatting via `usethis::use_air()`
- Add `format-check.yaml` GitHub Actions workflow to check formatting on PRs
- Update CONTRIBUTING.md with Air setup instructions
- Reformat all R code with `air format .`

Related to hubverse-org/hubDevs#45

## Notes

Air is Posit's new R code formatter. The project-based configuration ensures formatting only applies within this repo - contributors' personal projects remain unaffected.

### ⚠️ Potential lintr failures

If the lint workflow fails on this PR, please ignore those failures for now. Recent changes in lintr (v3.3.0+) may surface pre-existing issues unrelated to this formatting migration. If lint failures occur, please open a separate issue to address them independently.
