### PR TITLE
Offer only the workflows a hub can add, and add paired workflows together

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     gh,
     purrr,
     rlang (>= 1.0.0),
-    utils
+    utils,
+    yaml
 URL: https://github.com/hubverse-org/hubCI,
     https://hubverse-org.github.io/hubCI/
 BugReports: https://github.com/hubverse-org/hubCI/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # hubCI 0.0.1.9000
 
+* `use_hub_github_action()` now fails with the list of workflows a hub can add when asked for anything else, such as the `pr-comment` composite action, instead of reporting a download error.
+* Workflows that only work as a pair are now added together: asking for `validate-submission` also adds `validate-submission-comment`, which posts the validation result on the submitter's pull request.
+
 * `use_hub_github_action()` now accepts any git reference GitHub recognises, including branch names containing slashes such as `"ak/my-feature/27"`, which previously failed with a 404 error.
 * `use_hub_github_action()` now leaves an existing workflow file untouched when it already matches the version being downloaded, and asks before overwriting one that differs (in a non-interactive session it overwrites and says so).
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -1,3 +1,5 @@
 # The repository hosting the hubverse GitHub Action workflows.
 actions_owner <- "hubverse-org"
 actions_repo <- "hubverse-actions"
+# The repository as it appears in messages and URLs.
+actions_slug <- paste0(actions_owner, "/", actions_repo)

--- a/R/use_hub_github_action.R
+++ b/R/use_hub_github_action.R
@@ -3,17 +3,18 @@
 # against the gh API. Unlike write_over(), a non-interactive session overwrites
 # a differing file rather than refusing to.
 
-#' Hubverse GitHub Action setup
+#' Hubverse GitHub Actions workflow setup
 #'
 #' Sets up common continuous integration (CI) workflows for a hub
 #' that is hosted on GitHub using
 #' [GitHub Actions](https://github.com/features/actions).
-#' Available actions are hosted in repository [hubverse-org/hubverse-actions](
+#' Available workflows are hosted in repository [hubverse-org/hubverse-actions](
 #' https://github.com/hubverse-org/hubverse-actions)
-#' The function creates the necessary directories and downloads the requested GitHub Action yaml file.
-#' @param name Name of workflow, i.e. the name of one of the [action repository](
+#' The function creates the necessary directories and downloads the requested workflow `.yaml` file.
+#' @param name Name of workflow, i.e. the name of one of the [workflow repository](
 #' https://github.com/hubverse-org/hubverse-actions)
-#' directories containing a GitHub Action workflow `.yaml` file.
+#' directories holding a workflow `.yaml` file of the same name. Asking for
+#' anything else, such as a composite action, lists the workflows a hub can add.
 #' @param ref Desired Git reference, usually the name of a tag (`"v0.1.0"`) or
 #'   branch (`"main"`, including branch names containing slashes such as
 #'   `"ak/my-feature/27"`). Other possibilities include a commit SHA (`"d1c516d"`)
@@ -21,18 +22,23 @@
 #'   defaults to the latest published release of `hubverse-org/hubverse-actions`
 #'   (<https://github.com/hubverse-org/hubverse-actions/releases>)
 #'
-#' @returns The path of the workflow file, invisibly. Called for the side
-#'   effect of writing `.github/workflows/<name>.yaml`.
+#' @returns The paths of the workflow files added, invisibly. Called for the
+#'   side effect of writing `.github/workflows/<name>.yaml`.
 #'
 #' @details
 #' The workflow is written to the root of the hub, i.e. the closest enclosing
 #' directory containing a `hub-config/` directory, falling back to the working
-#' directory if there is none.
+#' directory if there is none within the repository you are in.
+#'
+#' Some workflows only work as a pair, one running the checks and another
+#' posting their result, and are added together: asking for
+#' `"validate-submission"` also adds `"validate-submission-comment"`.
 #'
 #' If the workflow file already exists, it is left alone when its contents match
 #' what is being downloaded. Otherwise, an interactive session asks before
 #' overwriting it, while a non-interactive one overwrites it and reports that it
-#' has done so.
+#' has done so. A paired workflow you did not ask for is the exception: local
+#' changes to it stand unless you confirm the overwrite, or ask for it by name.
 #'
 #' Inspired by `usethis::use_github_action()`, and additionally accepts branch
 #' names containing slashes, which that function truncates at the first slash.
@@ -46,13 +52,38 @@
 #' }
 use_hub_github_action <- function(name, ref = NULL) {
   ref <- ref %||% latest_release()
-  contents <- fetch_action_yaml(name, ref)
+  files <- resolve_workflows(name, ref)
 
   wd <- normalizePath(getwd(), winslash = "/", mustWork = TRUE)
   root <- hub_root(wd)
   if (!identical(root, wd)) {
     rlang::inform(c(i = sprintf("Using hub root '%s'", root)))
   }
+  paired <- setdiff(names(files), name)
+  if (length(paired) > 0L) {
+    rlang::inform(c(
+      i = sprintf(
+        "'%s' works as a pair with %s, so both are added.",
+        name,
+        paste0("'", paired, "'", collapse = " and ")
+      )
+    ))
+  }
+
+  paths <- purrr::imap_chr(
+    files,
+    write_workflow,
+    ref = ref,
+    root = root,
+    requested = name
+  )
+  invisible(unname(paths[!is.na(paths)]))
+}
+
+# Write one workflow file, reporting what happened to it. Returns the path of
+# the file now holding the workflow, or NA if an existing file was kept in its
+# place instead.
+write_workflow <- function(contents, name, ref, root, requested) {
   rel_dir <- file.path(".github", "workflows")
   rel_path <- file.path(rel_dir, paste0(name, ".yaml"))
   path <- file.path(root, rel_path)
@@ -61,11 +92,14 @@ use_hub_github_action <- function(name, ref = NULL) {
   if (existing) {
     if (identical(readBin(path, "raw", n = file.size(path)), contents)) {
       rlang::inform(c(v = sprintf("Leaving '%s' unchanged", rel_path)))
-      return(invisible(path))
+      return(path)
     }
-    if (!confirm_overwrite(rel_path)) {
+    # A workflow the hub did not ask for keeps its local edits unattended; ask
+    # for it by name to replace it.
+    unattended <- identical(name, requested)
+    if (!confirm_overwrite(rel_path, unattended = unattended)) {
       rlang::inform(c(x = sprintf("Not overwriting '%s'", rel_path)))
-      return(invisible(path))
+      return(NA_character_)
     }
   }
 
@@ -80,46 +114,11 @@ use_hub_github_action <- function(name, ref = NULL) {
       "%s '%s' from '%s'",
       if (existing) "Overwriting" else "Saving",
       rel_path,
-      action_source(name, ref)
+      workflow_source(name, ref)
     )
   ))
 
-  invisible(path)
-}
-
-# Download the contents of a workflow file from hubverse-actions. Uses the
-# contents endpoint, which takes the ref as a query parameter and therefore
-# handles refs containing slashes, unlike a `/blob/<ref>/<path>` URL, which
-# cannot be split into ref and path unambiguously.
-fetch_action_yaml <- function(name, ref, call = rlang::caller_env()) {
-  contents <- rlang::try_fetch(
-    gh(
-      "/repos/{owner}/{repo}/contents/{path}",
-      owner = actions_owner,
-      repo = actions_repo,
-      path = action_yaml_path(name),
-      ref = ref,
-      .accept = "application/vnd.github.raw"
-    ),
-    http_error_404 = function(cnd) {
-      rlang::abort(
-        c(
-          sprintf("Could not download '%s'.", action_source(name, ref)),
-          i = sprintf(
-            "Check that '%s' exists at that ref in <https://github.com/%s/%s>.",
-            action_yaml_path(name),
-            actions_owner,
-            actions_repo
-          )
-        ),
-        parent = cnd,
-        call = call
-      )
-    }
-  )
-  # gh returns the raw response with its own class attached, which writeBin
-  # rejects.
-  as.vector(contents)
+  path
 }
 
 # Locate the root of the hub containing `dir` (an already normalised path), i.e.
@@ -131,33 +130,23 @@ hub_root <- function(dir) {
     if (dir.exists(file.path(dir, "hub-config"))) {
       return(dir)
     }
+    # Stop at a repository boundary: a hub further up the tree is not the hub
+    # whose checkout we are standing in.
     parent <- dirname(dir)
-    if (identical(parent, dir)) {
+    if (file.exists(file.path(dir, ".git")) || identical(parent, dir)) {
       return(start)
     }
     dir <- parent
   }
 }
 
-confirm_overwrite <- function(path) {
+# Ask before replacing a file, if there is anyone to ask. `unattended` is the
+# answer when there is not.
+confirm_overwrite <- function(path, unattended) {
   if (!interactive()) {
-    return(TRUE)
+    return(unattended)
   }
   isTRUE(utils::askYesNo(sprintf("Overwrite pre-existing file '%s'?", path)))
-}
-
-action_yaml_path <- function(name) {
-  paste0(name, "/", name, ".yaml")
-}
-
-action_source <- function(name, ref) {
-  sprintf(
-    "%s/%s@%s/%s",
-    actions_owner,
-    actions_repo,
-    ref,
-    action_yaml_path(name)
-  )
 }
 
 # Get latest hubverse action release. Function largely sourced from

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,0 +1,174 @@
+# Which workflows a hub can add, and which of them belong together, both derived
+# from the hubverse-actions repository at the requested ref rather than recorded
+# here, so that adding a workflow there needs no change in hubCI.
+#
+# A directory holding `<dir>/<dir>.yaml` is an installable workflow. Composite
+# actions such as pr-comment ship an `action.yaml` and no workflow of their own,
+# so they are not offered. A workflow that names another in its `workflow_run`
+# trigger reports on that workflow's runs, and the two are added together: one
+# posts what the other found, and a hub wants both or neither.
+
+# The workflow files to write for `name`, as a named list of raw contents keyed
+# by workflow name. Errors if `name` is not an installable workflow at `ref`.
+#
+# Every workflow in the repository is downloaded, because which of them reports
+# on `name` can only be read from their contents. They are small, and the ones
+# that are not written are discarded.
+resolve_workflows <- function(name, ref, call = rlang::caller_env()) {
+  available <- installable_workflows(ref, call = call)
+  if (!name %in% available) {
+    rlang::abort(
+      c(
+        sprintf("'%s' is not a workflow you can add to a hub.", name),
+        i = sprintf(
+          "Available at '%s@%s': %s.",
+          actions_slug,
+          ref,
+          paste(available, collapse = ", ")
+        )
+      ),
+      call = call
+    )
+  }
+
+  files <- purrr::map(
+    rlang::set_names(available),
+    fetch_workflow_yaml,
+    ref = ref,
+    call = call
+  )
+  files[paired_with(name, files)]
+}
+
+# Directories in the repository at `ref` that hold a workflow of the same name.
+installable_workflows <- function(ref, call = rlang::caller_env()) {
+  paths <- repo_paths(ref, call = call)
+  dirs <- unique(sub("/.*", "", paths))
+  sort(dirs[workflow_yaml_path(dirs) %in% paths])
+}
+
+# Every path in the repository at `ref`. The ref reaches the API as a query
+# parameter and the tree as a commit SHA, so refs containing slashes work.
+repo_paths <- function(ref, call = rlang::caller_env()) {
+  commit <- rlang::try_fetch(
+    gh(
+      "/repos/{owner}/{repo}/commits",
+      owner = actions_owner,
+      repo = actions_repo,
+      sha = ref,
+      per_page = 1
+    ),
+    http_error_404 = function(cnd) {
+      rlang::abort(
+        c(
+          sprintf("Could not find ref '%s' in '%s'.", ref, actions_slug),
+          i = "`ref` should be a tag, branch, commit SHA or \"HEAD\"."
+        ),
+        parent = cnd,
+        call = call
+      )
+    }
+  )
+  tree <- gh(
+    "/repos/{owner}/{repo}/git/trees/{tree_sha}",
+    owner = actions_owner,
+    repo = actions_repo,
+    tree_sha = commit[[1]]$sha,
+    recursive = 1
+  )
+  if (isTRUE(tree$truncated)) {
+    rlang::abort(
+      sprintf(
+        "Could not list '%s@%s': the repository tree is too large.",
+        actions_slug,
+        ref
+      ),
+      call = call
+    )
+  }
+  purrr::map_chr(tree$tree, "path")
+}
+
+# `name` together with the workflows it is paired with: those it is triggered
+# by, and those triggered by it, since only the reporting workflow names the
+# other.
+paired_with <- function(name, files) {
+  links <- workflow_links(files)
+  union(
+    name,
+    c(
+      links[[name]],
+      names(links)[purrr::map_lgl(links, function(x) name %in% x)]
+    )
+  )
+}
+
+# For each workflow, the workflows it is triggered by, as directory names. Two
+# workflows sharing a `name:` both match, rather than the first one silently
+# winning.
+workflow_links <- function(files) {
+  meta <- purrr::map(files, workflow_meta)
+  workflow_names <- purrr::map_chr(meta, "name")
+  purrr::map(meta, function(x) names(meta)[workflow_names %in% x$triggered_by])
+}
+
+# A workflow's `name:`, and the names of the workflows whose runs trigger it.
+# `on:` takes a bare event or a list of them as well as a mapping, and neither
+# of those can hold a `workflow_run`. The handlers keep YAML 1.1 from reading
+# the `on:` key as a boolean, and from warning about large numbers elsewhere in
+# a file whose other fields are never read.
+workflow_meta <- function(contents) {
+  yaml <- yaml::yaml.load(
+    rawToChar(contents),
+    handlers = list(`bool#yes` = function(x) x, int = function(x) x)
+  )
+  events <- yaml[["on"]]
+  workflow_run <- if (is.list(events)) events[["workflow_run"]]
+  triggered_by <- if (is.list(workflow_run)) workflow_run[["workflows"]]
+  list(
+    name = yaml$name %||% "",
+    triggered_by = as.character(triggered_by %||% character())
+  )
+}
+
+# Download the contents of a workflow file from hubverse-actions. Uses the
+# contents endpoint, which takes the ref as a query parameter and therefore
+# handles refs containing slashes, unlike a `/blob/<ref>/<path>` URL, which
+# cannot be split into ref and path unambiguously.
+fetch_workflow_yaml <- function(name, ref, call = rlang::caller_env()) {
+  contents <- rlang::try_fetch(
+    gh(
+      "/repos/{owner}/{repo}/contents/{path}",
+      owner = actions_owner,
+      repo = actions_repo,
+      path = workflow_yaml_path(name),
+      ref = ref,
+      .accept = "application/vnd.github.raw"
+    ),
+    http_error_404 = function(cnd) {
+      rlang::abort(
+        c(
+          sprintf("Could not download '%s'.", workflow_source(name, ref)),
+          i = sprintf(
+            "Check that '%s' exists at that ref in <https://github.com/%s>.",
+            workflow_yaml_path(name),
+            actions_slug
+          )
+        ),
+        parent = cnd,
+        call = call
+      )
+    }
+  )
+  # gh returns the raw response with its own class attached, which writeBin
+  # rejects.
+  as.vector(contents)
+}
+
+workflow_yaml_path <- function(name) {
+  paste0(name, "/", name, ".yaml")
+}
+
+workflow_source <- function(name, ref) {
+  sprintf("%s@%s/%s", actions_slug, ref, workflow_yaml_path(name))
+}

--- a/man/use_hub_github_action.Rd
+++ b/man/use_hub_github_action.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/use_hub_github_action.R
 \name{use_hub_github_action}
 \alias{use_hub_github_action}
-\title{Hubverse GitHub Action setup}
+\title{Hubverse GitHub Actions workflow setup}
 \usage{
 use_hub_github_action(name, ref = NULL)
 }
 \arguments{
-\item{name}{Name of workflow, i.e. the name of one of the \href{https://github.com/hubverse-org/hubverse-actions}{action repository}
-directories containing a GitHub Action workflow \code{.yaml} file.}
+\item{name}{Name of workflow, i.e. the name of one of the \href{https://github.com/hubverse-org/hubverse-actions}{workflow repository}
+directories holding a workflow \code{.yaml} file of the same name. Asking for
+anything else, such as a composite action, lists the workflows a hub can add.}
 
 \item{ref}{Desired Git reference, usually the name of a tag (\code{"v0.1.0"}) or
 branch (\code{"main"}, including branch names containing slashes such as
@@ -18,25 +19,30 @@ defaults to the latest published release of \code{hubverse-org/hubverse-actions}
 (\url{https://github.com/hubverse-org/hubverse-actions/releases})}
 }
 \value{
-The path of the workflow file, invisibly. Called for the side
-effect of writing \verb{.github/workflows/<name>.yaml}.
+The paths of the workflow files added, invisibly. Called for the
+side effect of writing \verb{.github/workflows/<name>.yaml}.
 }
 \description{
 Sets up common continuous integration (CI) workflows for a hub
 that is hosted on GitHub using
 \href{https://github.com/features/actions}{GitHub Actions}.
-Available actions are hosted in repository \href{https://github.com/hubverse-org/hubverse-actions}{hubverse-org/hubverse-actions}
-The function creates the necessary directories and downloads the requested GitHub Action yaml file.
+Available workflows are hosted in repository \href{https://github.com/hubverse-org/hubverse-actions}{hubverse-org/hubverse-actions}
+The function creates the necessary directories and downloads the requested workflow \code{.yaml} file.
 }
 \details{
 The workflow is written to the root of the hub, i.e. the closest enclosing
 directory containing a \verb{hub-config/} directory, falling back to the working
-directory if there is none.
+directory if there is none within the repository you are in.
+
+Some workflows only work as a pair, one running the checks and another
+posting their result, and are added together: asking for
+\code{"validate-submission"} also adds \code{"validate-submission-comment"}.
 
 If the workflow file already exists, it is left alone when its contents match
 what is being downloaded. Otherwise, an interactive session asks before
 overwriting it, while a non-interactive one overwrites it and reports that it
-has done so.
+has done so. A paired workflow you did not ask for is the exception: local
+changes to it stand unless you confirm the overwrite, or ask for it by name.
 
 Inspired by \code{usethis::use_github_action()}, and additionally accepts branch
 names containing slashes, which that function truncates at the first slash.

--- a/tests/testthat/test-use_hub_github_action.R
+++ b/tests/testthat/test-use_hub_github_action.R
@@ -1,30 +1,76 @@
-mock_workflow <- "name: mock workflow\n"
+# A stand-in for hubverse-actions: three workflow directories, one of which
+# reports on another, plus a composite action that a hub cannot add.
+mock_workflows <- list(
+  "validate-config" = "name: Hub Config Validation (R)\non:\n  push:\n",
+  "validate-submission" = "name: Hub Submission Validation (R)\non:\n  pull_request:\n",
+  "validate-submission-comment" = paste0(
+    "name: Post Submission Validation Result\n",
+    "on:\n  workflow_run:\n",
+    "    workflows: [\"Hub Submission Validation (R)\"]\n",
+    "    types: [completed]\n"
+  )
+)
+mock_actions <- "pr-comment"
 
-# Stub the workflow download: the fake gh() records the arguments it was given
-# and returns `mock_workflow` as raw bytes, the shape of a real raw contents
-# response.
+# Stub the calls to hubverse-actions, serving the fixture above: the commit and
+# tree that give the repository layout, and the raw contents of each workflow.
 #
 # Use it when a test is about our own behaviour around the download (the
-# messages, where the file lands, how an existing file is treated) rather than
-# about the contents of a real workflow, so the test neither hits the network
-# nor depends on what a given ref happens to contain, or on a branch that will
+# messages, where files land, how an existing file is treated) rather than about
+# the contents of a real workflow, so the test neither hits the network nor
+# depends on what a given ref happens to contain, or on a branch that will
 # eventually be deleted.
 #
-# Returns an environment whose `call` element holds the arguments of the last
-# stubbed gh() call, for tests that assert on the request itself; tests that
-# only care about the side effects can ignore it. `env` is the calling test's
-# frame, because local_mocked_bindings() would otherwise undo the mock as soon
-# as this helper returned.
-local_mocked_action <- function(env = parent.frame()) {
-  args <- new.env(parent = emptyenv())
+# Returns an environment whose `calls` element holds every stubbed gh() call, in
+# order, for tests that assert on the requests themselves; tests that only care
+# about the side effects can ignore it. `env` is the calling test's frame,
+# because local_mocked_bindings() would otherwise undo the mock as soon as this
+# helper returned.
+local_mocked_actions_repo <- function(
+  dirs = names(mock_workflows),
+  env = parent.frame()
+) {
+  recorder <- new.env(parent = emptyenv())
+  recorder$calls <- list()
+  paths <- c(
+    "README.md",
+    paste0(mock_actions, "/action.yaml"),
+    unlist(lapply(dirs, function(d) {
+      c(paste0(d, "/README.md"), paste0(d, "/", d, ".yaml"))
+    }))
+  )
+
   testthat::local_mocked_bindings(
     gh = function(endpoint, ...) {
-      args$call <- list(endpoint = endpoint, ...)
-      charToRaw(mock_workflow)
+      args <- list(...)
+      recorder$calls <- c(
+        recorder$calls,
+        list(c(list(endpoint = endpoint), args))
+      )
+      if (grepl("/commits$", endpoint)) {
+        return(list(list(sha = "0f1e2d3")))
+      }
+      if (grepl("/git/trees/", endpoint)) {
+        return(list(
+          truncated = FALSE,
+          tree = lapply(paths, function(p) list(path = p))
+        ))
+      }
+      if (grepl("/contents/", endpoint)) {
+        dir <- sub("/.*", "", args$path)
+        if (!dir %in% names(mock_workflows)) {
+          rlang::abort(
+            "GitHub API error (404): Not Found",
+            class = "http_error_404"
+          )
+        }
+        return(charToRaw(mock_workflows[[dir]]))
+      }
+      rlang::abort(paste("Unexpected endpoint:", endpoint))
     },
     .env = env
   )
-  args
+  recorder
 }
 
 test_that("use_hub_github_action works", {
@@ -46,8 +92,8 @@ test_that("use_hub_github_action works", {
   # r-universe, so this marks which version of the workflow was downloaded.
   expect_false(any(grepl("remotes::install_github", workflow)))
 
-  fs::file_delete(ga_path)
-  expect_false(fs::file_exists(ga_path))
+  # Start clean: the default ref may pair this workflow with another.
+  fs::dir_delete(".github")
 
   use_hub_github_action(name = "validate-submission", ref = "v0.0.1")
 
@@ -63,19 +109,18 @@ test_that("use_hub_github_action works", {
 
 test_that("use_hub_github_action reports what it writes", {
   withr::local_dir(withr::local_tempdir())
-  local_mocked_action()
+  local_mocked_actions_repo()
 
   msgs <- capture_messages(
-    use_hub_github_action(name = "validate-submission", ref = "v0.0.1")
+    use_hub_github_action(name = "validate-config", ref = "v0.0.1")
   )
 
   expect_match(msgs, "Creating '.github/workflows/'", all = FALSE, fixed = TRUE)
   expect_match(
     msgs,
     paste0(
-      "Saving '.github/workflows/validate-submission.yaml' from ",
-      "'hubverse-org/hubverse-actions@v0.0.1/",
-      "validate-submission/validate-submission.yaml'"
+      "Saving '.github/workflows/validate-config.yaml' from ",
+      "'hubverse-org/hubverse-actions@v0.0.1/validate-config/validate-config.yaml'"
     ),
     all = FALSE,
     fixed = TRUE
@@ -84,74 +129,118 @@ test_that("use_hub_github_action reports what it writes", {
 
 test_that("use_hub_github_action handles refs containing slashes", {
   withr::local_dir(withr::local_tempdir())
-  args <- local_mocked_action()
+  ref <- "ak/post-validation-results-to-pr/53"
+  recorder <- local_mocked_actions_repo()
 
-  use_hub_github_action(
-    name = "validate-submission",
-    ref = "ak/post-validation-results-to-pr/53"
-  )
+  use_hub_github_action(name = "validate-config", ref = ref)
 
   # The ref is passed separately from the path, so slashes in a branch name
   # survive instead of being truncated at the first segment.
-  expect_equal(args$call$ref, "ak/post-validation-results-to-pr/53")
+  download <- Filter(
+    function(x) grepl("/contents/", x$endpoint),
+    recorder$calls
+  )[[1]]
+  expect_equal(download$ref, ref)
+  expect_equal(download$path, "validate-config/validate-config.yaml")
+  # The repository layout is read at the same ref, which the commits endpoint
+  # takes as a query parameter for the same reason.
+  expect_equal(recorder$calls[[1]]$sha, ref)
   expect_equal(
-    args$call$path,
-    "validate-submission/validate-submission.yaml"
-  )
-  expect_equal(
-    readLines(".github/workflows/validate-submission.yaml"),
-    "name: mock workflow"
+    readLines(".github/workflows/validate-config.yaml"),
+    c("name: Hub Config Validation (R)", "on:", "  push:")
   )
 })
 
-test_that("use_hub_github_action writes to the hub root", {
-  hub <- withr::local_tempdir()
-  fs::dir_create(fs::path(hub, "hub-config"))
-  fs::dir_create(fs::path(hub, "model-output", "team-model"))
-  withr::local_dir(fs::path(hub, "model-output", "team-model"))
-  local_mocked_action()
+test_that("use_hub_github_action rejects anything but a workflow", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
 
-  expect_message(
-    use_hub_github_action(name = "validate-submission", ref = "main"),
-    "Using hub root"
+  err <- expect_error(
+    use_hub_github_action(name = "pr-comment", ref = "main"),
+    "'pr-comment' is not a workflow you can add to a hub"
   )
-
-  expect_true(fs::file_exists(fs::path(
-    hub,
-    ".github/workflows/validate-submission.yaml"
-  )))
+  expect_match(
+    conditionMessage(err),
+    "validate-config, validate-submission, validate-submission-comment"
+  )
+  expect_error(
+    use_hub_github_action(name = "no-such-thing", ref = "main"),
+    "is not a workflow you can add to a hub"
+  )
   expect_false(fs::dir_exists(".github"))
 })
 
-test_that("use_hub_github_action leaves an identical workflow unchanged", {
+test_that("use_hub_github_action adds paired workflows together", {
   withr::local_dir(withr::local_tempdir())
-  local_mocked_action()
+  local_mocked_actions_repo()
+
+  expect_message(
+    paths <- use_hub_github_action(name = "validate-submission", ref = "main"),
+    "works as a pair with 'validate-submission-comment'"
+  )
+
+  expect_true(fs::file_exists(".github/workflows/validate-submission.yaml"))
+  expect_true(fs::file_exists(
+    ".github/workflows/validate-submission-comment.yaml"
+  ))
+  expect_length(paths, 2)
+})
+
+test_that("use_hub_github_action adds a workflow its companion reports on", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+
+  use_hub_github_action(name = "validate-submission-comment", ref = "main")
+
+  # The comment workflow is useless without the one whose runs trigger it.
+  expect_true(fs::file_exists(".github/workflows/validate-submission.yaml"))
+  expect_true(fs::file_exists(
+    ".github/workflows/validate-submission-comment.yaml"
+  ))
+})
+
+test_that("use_hub_github_action keeps local edits to a paired workflow", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+  customised <- ".github/workflows/validate-submission.yaml"
+  fs::dir_create(".github/workflows")
+  writeLines("name: Hub Submission Validation (R) # customised", customised)
+
+  # The hub asked for the comment workflow, so its own edits to the workflow
+  # that comes with it are not silently replaced.
+  paths <- NULL
+  expect_message(
+    paths <- use_hub_github_action(
+      name = "validate-submission-comment",
+      ref = "main"
+    ),
+    "Not overwriting '.github/workflows/validate-submission.yaml'"
+  )
+
+  expect_equal(
+    readLines(customised),
+    "name: Hub Submission Validation (R) # customised"
+  )
+  expect_true(fs::file_exists(
+    ".github/workflows/validate-submission-comment.yaml"
+  ))
+  expect_length(paths, 1)
+})
+
+test_that("use_hub_github_action replaces a workflow asked for by name", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+  customised <- ".github/workflows/validate-submission.yaml"
+  fs::dir_create(".github/workflows")
+  writeLines("name: Hub Submission Validation (R) # customised", customised)
 
   use_hub_github_action(name = "validate-submission", ref = "main")
 
-  expect_message(
-    use_hub_github_action(name = "validate-submission", ref = "main"),
-    "Leaving '.github/workflows/validate-submission.yaml' unchanged"
-  )
+  expect_equal(readLines(customised)[1], "name: Hub Submission Validation (R)")
 })
 
-test_that("use_hub_github_action overwrites a differing workflow", {
+test_that("use_hub_github_action reports an unknown ref", {
   withr::local_dir(withr::local_tempdir())
-  local_mocked_action()
-  ga_path <- ".github/workflows/validate-submission.yaml"
-  fs::dir_create(".github/workflows")
-  writeLines("stale", ga_path)
-
-  expect_message(
-    use_hub_github_action(name = "validate-submission", ref = "main"),
-    "Overwriting '.github/workflows/validate-submission.yaml'"
-  )
-  expect_equal(readLines(ga_path), "name: mock workflow")
-})
-
-test_that("use_hub_github_action errors informatively on an unknown workflow", {
-  withr::local_dir(withr::local_tempdir())
-
   local_mocked_bindings(
     gh = function(...) {
       rlang::abort(
@@ -162,8 +251,115 @@ test_that("use_hub_github_action errors informatively on an unknown workflow", {
   )
 
   expect_error(
-    use_hub_github_action(name = "no-such-workflow", ref = "main"),
-    "Could not download 'hubverse-org/hubverse-actions@main/no-such-workflow"
+    use_hub_github_action(name = "validate-config", ref = "mian"),
+    "Could not find ref 'mian' in 'hubverse-org/hubverse-actions'"
   )
-  expect_false(fs::file_exists(".github/workflows/no-such-workflow.yaml"))
+})
+
+test_that("workflow_links reads every form of `on:`", {
+  files <- purrr::map(
+    list(
+      shorthand = "name: A\non: [push, pull_request]\n",
+      single = "name: B\non: push\n",
+      mapping = "name: C\non:\n  push:\n    branches: main\n",
+      # Two workflows share the name "A", so both are linked, not just one.
+      listener = "name: D\non:\n  workflow_run:\n    workflows: [\"A\"]\n",
+      twin = "name: A\non: [push]\n"
+    ),
+    charToRaw
+  )
+
+  expect_equal(
+    workflow_links(files),
+    list(
+      shorthand = character(),
+      single = character(),
+      mapping = character(),
+      listener = c("shorthand", "twin"),
+      twin = character()
+    )
+  )
+})
+
+test_that("use_hub_github_action leaves unpaired workflows alone", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+
+  use_hub_github_action(name = "validate-config", ref = "main")
+
+  expect_equal(
+    fs::path_file(fs::dir_ls(".github/workflows")),
+    "validate-config.yaml"
+  )
+})
+
+test_that("use_hub_github_action writes to the hub root", {
+  hub <- withr::local_tempdir()
+  fs::dir_create(fs::path(hub, "hub-config"))
+  fs::dir_create(fs::path(hub, "model-output", "team-model"))
+  withr::local_dir(fs::path(hub, "model-output", "team-model"))
+  local_mocked_actions_repo()
+
+  expect_message(
+    use_hub_github_action(name = "validate-config", ref = "main"),
+    "Using hub root"
+  )
+
+  expect_true(fs::file_exists(fs::path(
+    hub,
+    ".github/workflows/validate-config.yaml"
+  )))
+  expect_false(fs::dir_exists(".github"))
+})
+
+test_that("use_hub_github_action leaves an identical workflow unchanged", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+
+  use_hub_github_action(name = "validate-config", ref = "main")
+
+  expect_message(
+    use_hub_github_action(name = "validate-config", ref = "main"),
+    "Leaving '.github/workflows/validate-config.yaml' unchanged"
+  )
+})
+
+test_that("use_hub_github_action overwrites a differing workflow", {
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_actions_repo()
+  ga_path <- ".github/workflows/validate-config.yaml"
+  fs::dir_create(".github/workflows")
+  writeLines("stale", ga_path)
+
+  expect_message(
+    use_hub_github_action(name = "validate-config", ref = "main"),
+    "Overwriting '.github/workflows/validate-config.yaml'"
+  )
+  expect_equal(readLines(ga_path)[1], "name: Hub Config Validation (R)")
+})
+
+test_that("use_hub_github_action errors informatively on a failed download", {
+  withr::local_dir(withr::local_tempdir())
+  # Listed in the repository, but its contents cannot be fetched.
+  local_mocked_actions_repo(dirs = c(names(mock_workflows), "ghost"))
+
+  expect_error(
+    use_hub_github_action(name = "ghost", ref = "main"),
+    "Could not download 'hubverse-org/hubverse-actions@main/ghost"
+  )
+  expect_false(fs::file_exists(".github/workflows/ghost.yaml"))
+})
+
+test_that("use_hub_github_action stops looking for a hub at the repository", {
+  repo <- withr::local_tempdir()
+  # A hub above the repository we are standing in is a different project.
+  fs::dir_create(fs::path(repo, "hub-config"))
+  fs::dir_create(fs::path(repo, "pkg", ".git"))
+  withr::local_dir(fs::path(repo, "pkg"))
+  local_mocked_actions_repo()
+
+  use_hub_github_action(name = "validate-config", ref = "main")
+
+  expect_true(fs::file_exists(".github/workflows/validate-config.yaml"))
+  expect_false(fs::dir_exists(fs::path(repo, ".github")))
 })


### PR DESCRIPTION
Resolves #26

Stacked on #28, so the base is that branch and this diff shows only the new change. Merge #28 first.

`use_hub_github_action()` now works two things out from hubverse-actions at the requested ref, rather than trusting whatever name it is handed:

- **Which directories hold a workflow a hub can add** — one containing `<dir>/<dir>.yaml`. `pr-comment` and `resolve-pr` are composite actions shipping an `action.yaml`, so asking for one now says `'pr-comment' is not a workflow you can add to a hub` and lists the ones that are, instead of failing with a download error.
- **Which workflows come as a set** — a workflow whose `workflow_run` trigger names another reports on that workflow's runs, and neither is much use alone. `use_hub_github_action("validate-submission")` now also adds `validate-submission-comment`, and asking for the comment workflow adds the validator.

The issue proposed a manifest shipped by hubverse-actions; this doesn't add one. The repository layout already says what is installable, and the companion link is already declared natively in the `workflow_run` trigger that `validate-submission-comment.yaml` needs anyway. Deriving both means adding a workflow to hubverse-actions still needs no change in hubCI, with no second source of truth to keep in sync, and it works at refs that predate the feature, including every existing release.

The cost is requests: resolving the pairing means reading every workflow's `name:` and trigger, so a call makes 2 + N requests (7 against `main` today) where it used to make 1. The files are a few hundred bytes each, so this is round trips and rate-limit budget in a function run by hand a handful of times per hub, not bandwidth.

One deliberate refinement to the overwrite behaviour from #28: a paired workflow you did not name keeps its local edits unless you confirm the replacement or ask for it by name. Silently replacing a hub's customised `validate-submission.yaml` because someone asked for the comment workflow would be an unpleasant surprise in a setup script.

Internal helpers are renamed from `action_*` to `workflow_*`, since they fetch workflows and this change is about not conflating the two.
